### PR TITLE
add and mul operations do not issue a numexpr warning as of version 2…

### DIFF
--- a/pandas/core/computation/check.py
+++ b/pandas/core/computation/check.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import re
+
 from pandas.compat._optional import import_optional_dependency
 
 ne = import_optional_dependency("numexpr", errors="warn")
 NUMEXPR_INSTALLED = ne is not None
-
-__all__ = ["NUMEXPR_INSTALLED"]
+if ne is None:
+    # use tuple to make types consistent with mypy
+    NUMEXPR_VERSION = (0, 0, 0)
+else:
+    NUMEXPR_VERSION = tuple(map(int, re.findall(r"(\d+)", ne.__version__)))

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -20,6 +20,7 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.core.computation import expressions as expr
+from pandas.core.computation.check import NUMEXPR_VERSION
 from pandas.tests.frame.common import (
     _check_mixed_float,
     _check_mixed_int,
@@ -1095,9 +1096,12 @@ class TestFrameArithmetic:
         skip = {
             (operator.truediv, "bool"),
             (operator.pow, "bool"),
-            (operator.add, "bool"),
-            (operator.mul, "bool"),
         }
+        if NUMEXPR_VERSION and NUMEXPR_VERSION <= (2, 13, 0):
+            skip |= {
+                (operator.add, "bool"),
+                (operator.mul, "bool"),
+            }
 
         elem = DummyElement(value, dtype)
         df = DataFrame({"A": [elem.value, elem.value]}, dtype=elem.dtype)

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -25,7 +25,10 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core import ops
 from pandas.core.computation import expressions as expr
-from pandas.core.computation.check import NUMEXPR_INSTALLED
+from pandas.core.computation.check import (
+    NUMEXPR_INSTALLED,
+    NUMEXPR_VERSION,
+)
 
 
 @pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
@@ -350,7 +353,9 @@ class TestSeriesArithmetic:
         # GH#22962
         warning = (
             UserWarning
-            if request.node.callspec.id == "numexpr" and NUMEXPR_INSTALLED
+            if request.node.callspec.id == "numexpr"
+            and NUMEXPR_INSTALLED
+            and NUMEXPR_VERSION <= (2, 13, 0)
             else None
         )
         ser = Series([True, None, False], dtype="boolean")

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -8,6 +8,7 @@ from pandas import option_context
 import pandas._testing as tm
 from pandas.core.api import DataFrame
 from pandas.core.computation import expressions as expr
+from pandas.core.computation.check import NUMEXPR_VERSION
 
 
 @pytest.fixture
@@ -318,7 +319,7 @@ class TestExpressions:
             f(df, True)
 
     @pytest.mark.parametrize(
-        "op_str,opname", [("+", "add"), ("*", "mul"), ("-", "sub")]
+        "op_str, opname", [("+", "add"), ("*", "mul"), ("-", "sub")]
     )
     def test_bool_ops_warn_on_arithmetic(self, op_str, opname, monkeypatch):
         n = 10
@@ -328,6 +329,8 @@ class TestExpressions:
                 "b": np.random.default_rng(2).random(n) > 0.5,
             }
         )
+        if NUMEXPR_VERSION and NUMEXPR_VERSION >= (2, 13, 1) and op_str in ("+", "*"):
+            return
 
         subs = {"+": "|", "*": "&", "-": "^"}
         sub_funcs = {"|": "or_", "&": "and_", "^": "xor"}


### PR DESCRIPTION
`numexpr=2.13.1` introduces some test failures where expected warnings are no longer issued when applying addition and multiplication to bools. 

- closes ##62545 
